### PR TITLE
Use OpenJDK 11 for a release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ jobs:
   include:
     - script: sbt "++ ${TRAVIS_SCALA_VERSION}!" test
     - stage: release
-      jdk: oraclejdk8
+      jdk: openjdk11
       script: sbt ci-release
 
 jdk:


### PR DESCRIPTION
OracleJDK8 doesn't work now.
https://travis-ci.org/github/failurewall/failurewall/jobs/695593746