### PR TITLE
Use OpenJDK 8 for a release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ jobs:
   include:
     - script: sbt "++ ${TRAVIS_SCALA_VERSION}!" test
     - stage: release
-      jdk: oraclejdk8
+      jdk: openjdk8
       script: sbt ci-release
 
 jdk:

--- a/failurewall-patterns/src/test/scala/failurewall/MicroserviceFailurewallSpec.scala
+++ b/failurewall-patterns/src/test/scala/failurewall/MicroserviceFailurewallSpec.scala
@@ -24,7 +24,7 @@ class MicroserviceFailurewallSpec extends WallSpec with BeforeAndAfterAll {
         system.scheduler,
         maxFailures,
         100.seconds,
-        100.seconds,
+        1000.seconds,
         isSuccess.andThen {
           case true => Available
           case false => Unavailable


### PR DESCRIPTION
OracleJDK 8 is unavailable now.
https://travis-ci.org/github/failurewall/failurewall/jobs/695593746