### PR TITLE
parepare Scala 3

### DIFF
--- a/failurewall-akka/src/test/scala/failurewall/circuitbreaker/AkkaCircuitBreakerFailurewallSpec.scala
+++ b/failurewall-akka/src/test/scala/failurewall/circuitbreaker/AkkaCircuitBreakerFailurewallSpec.scala
@@ -20,7 +20,7 @@ class AkkaCircuitBreakerFailurewallSpec extends AkkaSpec {
   "AkkaCircuitBreakerFailurewall" when {
     "in CLOSED state" should {
       "invoke the given body" in {
-        forAll { result: Int =>
+        forAll { (result: Int) =>
           val breaker = circuitBreaker()
           val failurewall = AkkaCircuitBreakerFailurewall[Int](breaker, executor)
           val body = BodyPromise[Int]()
@@ -73,7 +73,7 @@ class AkkaCircuitBreakerFailurewallSpec extends AkkaSpec {
       }
 
       "switch into the OPEN state if too many failures occurs" in {
-        forAll(Gen.chooseNum(1, 10)) { failureTimes: Int =>
+        forAll(Gen.chooseNum(1, 10)) { (failureTimes: Int) =>
           val breaker = circuitBreaker(maxFailure = failureTimes)
           val isOpen = new AtomicBoolean(false)
           breaker.onOpen(isOpen.set(true))

--- a/failurewall-akka/src/test/scala/failurewall/retry/AkkaRetryFailurewallSpec.scala
+++ b/failurewall-akka/src/test/scala/failurewall/retry/AkkaRetryFailurewallSpec.scala
@@ -28,7 +28,7 @@ class AkkaRetryFailurewallSpec extends AkkaSpec with MockitoSugar {
 
   "AkkaRetryFailurewall" should {
     "throws IllegalArgumentException if `maxTrialTimes` is less than or equal to 0" in {
-      forAll(Gen.chooseNum(Int.MinValue, 0)) { maxTrialTimes: Int =>
+      forAll(Gen.chooseNum(Int.MinValue, 0)) { (maxTrialTimes: Int) =>
         intercept[IllegalArgumentException] {
           new AkkaRetryFailurewall[Int](
             maxTrialTimes,
@@ -42,7 +42,7 @@ class AkkaRetryFailurewallSpec extends AkkaSpec with MockitoSugar {
     }
 
     "finish if it succeeds calling body" in {
-      forAll(Gen.chooseNum(1, 10)) { successfulTrial: Int =>
+      forAll(Gen.chooseNum(1, 10)) { (successfulTrial: Int) =>
         val strategy = mockedStrategy()
         val failurewall = AkkaRetryFailurewall[Int](20, strategy, system.scheduler, executor)
 
@@ -57,7 +57,7 @@ class AkkaRetryFailurewallSpec extends AkkaSpec with MockitoSugar {
     }
 
     "retry until it retries max trial times" in {
-      forAll(Gen.chooseNum(1, 10)) { times: Int =>
+      forAll(Gen.chooseNum(1, 10)) { (times: Int) =>
         val strategy = mockedStrategy()
         val failurewall = AkkaRetryFailurewall[Int](times, strategy, system.scheduler, executor)
 
@@ -76,7 +76,7 @@ class AkkaRetryFailurewallSpec extends AkkaSpec with MockitoSugar {
     }
 
     "fail with the exception if the given body throws a exception" in {
-      forAll(Gen.chooseNum(1, 10)) { times: Int =>
+      forAll(Gen.chooseNum(1, 10)) { (times: Int) =>
         val strategy = mockedStrategy()
         val failurewall = AkkaRetryFailurewall[Int](times, strategy, system.scheduler, executor)
 
@@ -91,7 +91,7 @@ class AkkaRetryFailurewallSpec extends AkkaSpec with MockitoSugar {
     }
 
     "retry if feedback returns false" in {
-      forAll(Gen.chooseNum(1, 10)) { times: Int =>
+      forAll(Gen.chooseNum(1, 10)) { (times: Int) =>
         val strategy = mockedStrategy()
         val failurewall = AkkaRetryFailurewall.withFeedback[Int](
           times,

--- a/failurewall-core/src/test/scala/failurewall/retry/BackoffStrategySpec.scala
+++ b/failurewall-core/src/test/scala/failurewall/retry/BackoffStrategySpec.scala
@@ -69,7 +69,7 @@ class BackoffStrategySpec extends WallSpec {
     }
 
     "throws IllegalArgumentException if the given trialTimes <= 0" in {
-      forAll(Gen.choose(Int.MinValue, 0)) { trialTimes: Int =>
+      forAll(Gen.choose(Int.MinValue, 0)) { (trialTimes: Int) =>
         val strategy = ExponentialBackoffStrategy(1.millis, 1.millis)
         intercept[IllegalArgumentException] {
           strategy.nextDelay(trialTimes)

--- a/failurewall-core/src/test/scala/failurewall/retry/RetryFailurewallSpec.scala
+++ b/failurewall-core/src/test/scala/failurewall/retry/RetryFailurewallSpec.scala
@@ -18,7 +18,7 @@ class RetryFailurewallSpec extends WallSpec {
 
   "RetryFailurewall" should {
     "throws IllegalArgumentException if `maxTrialTimes` is less than or equal to 0" in {
-      forAll(Gen.chooseNum(Int.MinValue, 0)) { times: Int =>
+      forAll(Gen.chooseNum(Int.MinValue, 0)) { (times: Int) =>
         intercept[IllegalArgumentException] {
           new RetryFailurewall[Int](times, _ => ShouldNotRetry, executor)
         }
@@ -26,7 +26,7 @@ class RetryFailurewallSpec extends WallSpec {
     }
 
     "finish if it succeeds calling body" in {
-      forAll(Gen.chooseNum(1, 10)) { successfulTrial: Int =>
+      forAll(Gen.chooseNum(1, 10)) { (successfulTrial: Int) =>
         val body = new RetriableBody(successfulTrial)
         val failurewall = RetryFailurewall[Int](20, executor)
         val actual = failurewall.call(body.future)
@@ -35,7 +35,7 @@ class RetryFailurewallSpec extends WallSpec {
     }
 
     "retry until it retries max trial times" in {
-      forAll(Gen.chooseNum(1, 10)) { times: Int =>
+      forAll(Gen.chooseNum(1, 10)) { (times: Int) =>
         val failurewall = RetryFailurewall[Int](times, executor)
         val body = BodyPromise[Int]()
         val error = new RuntimeException
@@ -48,7 +48,7 @@ class RetryFailurewallSpec extends WallSpec {
     }
 
     "fail with the exception if the given body throws a exception" in {
-      forAll(Gen.chooseNum(1, 10)) { times: Int =>
+      forAll(Gen.chooseNum(1, 10)) { (times: Int) =>
         val failurewall = RetryFailurewall[Int](times, executor)
         val error = new RuntimeException
         val actual = failurewall.call(throw error)
@@ -57,7 +57,7 @@ class RetryFailurewallSpec extends WallSpec {
     }
 
     "retry if feedback returns false" in {
-      forAll(Gen.chooseNum(1, 10)) { times: Int =>
+      forAll(Gen.chooseNum(1, 10)) { (times: Int) =>
         val failurewall = RetryFailurewall.withFeedback[Int](times, executor) {
           case Success(10) => ShouldRetry
           case Success(_) => ShouldNotRetry

--- a/failurewall-core/src/test/scala/failurewall/semaphore/StdSemaphoreFailurewallSpec.scala
+++ b/failurewall-core/src/test/scala/failurewall/semaphore/StdSemaphoreFailurewallSpec.scala
@@ -11,7 +11,7 @@ class StdSemaphoreFailurewallSpec extends WallSpec {
   "StdSemaphoreFailurewall" when {
     "permits are available" should {
       "invoke the given body" in {
-        forAll { result: Int =>
+        forAll { (result: Int) =>
           val semaphore = new Semaphore(3)
           val failurewall = StdSemaphoreFailurewall[Int](semaphore, executor)
           val body = BodyPromise[Int]()


### PR DESCRIPTION
```
scala> List(1).map{ a => a }
val res0: List[Int] = List(1)

scala> List(1).map{ a: Int => a }
1 |List(1).map{ a: Int => a }
  |                    ^
  |parentheses are required around the parameter of a lambda
  |This construct can be rewritten automatically under -rewrite -source 3.0-migration.

scala> List(1).map{ (a: Int) => a }
val res1: List[Int] = List(1)
```